### PR TITLE
Scale up and down the size of the worker pool

### DIFF
--- a/lib/work_queue/options.ex
+++ b/lib/work_queue/options.ex
@@ -12,13 +12,15 @@ defmodule WorkQueue.Options do
   
   defp default_options do
     %{
-        worker_count:             round(processing_units*0.667),
-        report_each_result_to:    fn _ -> end,
-        report_progress_to:       fn _ -> end,
-        report_progress_interval: false,
-        worker_args:              [],
-        item_source:              [],
-        get_next_item:            false
+        worker_count:                 round(processing_units*0.667),
+        report_each_result_to:        fn _ -> end,
+        report_progress_to:           fn _ -> end,
+        report_progress_interval:     false,
+        worker_args:                  [],
+        item_source:                  [],
+        get_next_item:                false,
+        update_worker_count:          fn _, _, max -> max end,
+        update_worker_count_interval: 1000
      }
   end
   
@@ -57,7 +59,15 @@ defmodule WorkQueue.Options do
 
   defp option({:worker_count, :io_bound}, result),
   do:  option({:worker_count, 10.0}, result)
+
+  defp option({:update_worker_count, func}, result)
+  when is_function(func),
+  do:  update(result, :update_worker_count, func)
   
+  defp option({:update_worker_count_interval, n}, result)
+  when is_integer(n),
+  do:  update(result, :update_worker_count_interval, n)
+
   defp option({option, value}, _result) do
     { :error, "Invalid option [ #{option}: #{inspect value} ] to #{__MODULE__}" }
   end

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -111,4 +111,17 @@ defmodule OptionsTest do
     assert {:done, _, work=[]}         = get_next_item.(work)
     assert {:done, _, _work=[]}        = get_next_item.(work)
   end
+
+  test "can override update_worker_count function" do
+    callback = fn _ -> 10 end
+    given  = params(opts: [ update_worker_count: callback ])
+    assert {:ok, %{opts: opts}} = analyze(given, default_options)
+    assert Dict.delete(opts, :get_next_item) == default_options(update_worker_count: callback)
+  end
+  
+  test "can override update_worker_count_interval" do
+    given  = params(opts: [ update_worker_count_interval: 2000 ])
+    assert {:ok, %{opts: opts}} = analyze(given, default_options)
+    assert Dict.delete(opts, :get_next_item) == default_options(update_worker_count_interval: 2000)
+  end
 end


### PR DESCRIPTION
This pull request adds the ability to dynamically scale up or down the worker pool via a callback function invoked on a timer.

This could be used for several different use cases, for example:
- A gradual ramp of the number of workers is common for load testing applications.
- Random variation in the number of workers could be used for simulations of various sorts.
- By observing the actual CPU load with [cpu_sup](http://www.erlang.org/doc/man/cpu_sup.html), you could achieve better utilization for IO-bound subprocesses.

Two new options are introduced:

  `update_worker_count:` a callback for updating the worker count on a regular interval (Defaults to no update).
  `update_worker_count_interval:` the number of milliseconds to wait between checks for updated worker count.
